### PR TITLE
Bump lightblue to 0.3.3

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,12 +4,10 @@ import qualified Problems.DifficultProblems as DP (yes,notYes)
 import qualified Problems.NLPProblems as NLPP (yes,notYes)
 import qualified Data.Time as TIME
 
-test :: Bool
-test = PB.checkTests (SP.yes ++ SP.notYes ++ DP.yes ++ DP.notYes ++ NLPP.yes ++ NLPP.notYes)
-
 main :: IO()
 main = do
   start <- TIME.getCurrentTime
+  test <- PB.checkTests (SP.yes ++ SP.notYes ++ DP.yes ++ DP.notYes ++ NLPP.yes ++ NLPP.notYes)
   putStr $ if test then "passed" else "failed"
   end <- TIME.getCurrentTime
   putStrLn $ " with " ++ (show $TIME.diffUTCTime end start)

--- a/package.yaml
+++ b/package.yaml
@@ -22,7 +22,8 @@ dependencies:
   - data-default
   - split
   - cmdargs
-  - lightblue
+  - list-t >= 1.0.0.0
+  - lightblue >= 0.3
   - time >= 1.9.3
 
 library:
@@ -36,7 +37,7 @@ library:
   - Problems.NLPProblems
 
 executables:
-  waniTEST:
+  waniTEST: 
     source-dirs: app
     main: Main.hs
     ghc-options:  [-threaded, -rtsopts, -with-rtsopts=-N]

--- a/src/ProblemBase.hs
+++ b/src/ProblemBase.hs
@@ -30,42 +30,45 @@ module ProblemBase(
 )
  where
 import DTS.Prover.Wani.Prove (prove')
+import Control.Monad (forM)
 import qualified Data.Time as TIME
+import ListT (ListT,null)               --list-t
+import qualified Interface.Tree as I
 import qualified DTS.QueryTypes as QT
-import qualified DTS.UDTTdeBruijn as U
-import DTS.Labels (DTT)
+import qualified DTS.DTTdeBruijn as U
 
-type TestType = (Bool,QT.ProofSearchResult) -- ^ (predicted,result)
+type ProofSearchResult = ListT IO (I.Tree QT.DTTrule (U.Judgment))
+type TestType = (Bool,ProofSearchResult) -- ^ (predicted,result)
 
 executeWithDepthMode :: Int
   -> Maybe QT.LogicSystem
-  -> QT.ProofSearchQuery
-  -> QT.ProofSearchResult
-executeWithDepthMode depth mode = prove' QT.ProofSearchSetting{QT.maxDepth=Just depth,QT.maxTime=Just 10000000,QT.system=mode}
+  -> U.ProofSearchQuery
+  -> ProofSearchResult
+executeWithDepthMode depth mode = prove' QT.ProofSearchSetting{QT.maxDepth=Just depth,QT.maxTime=Just 10000000,QT.logicSystem=mode}
 
 executeWithMode :: Maybe QT.LogicSystem
-  -> QT.ProofSearchQuery
-  -> QT.ProofSearchResult
+  -> U.ProofSearchQuery
+  -> ProofSearchResult
 executeWithMode = executeWithDepthMode 5
 
 -- | To test with DNE
-executeWithDNE ::  QT.ProofSearchQuery -> QT.ProofSearchResult
+executeWithDNE ::  U.ProofSearchQuery -> ProofSearchResult
 executeWithDNE = executeWithDNEDepth 5
 
 -- -- | To test with default setting
-execute :: QT.ProofSearchQuery -> QT.ProofSearchResult
+execute :: U.ProofSearchQuery -> ProofSearchResult
 execute = executeWithDNE
 
 -- | To test with depth tuning
 executeWithDepth :: Int
-  -> QT.ProofSearchQuery
-  -> QT.ProofSearchResult
+  -> U.ProofSearchQuery
+  -> ProofSearchResult
 executeWithDepth depth = executeWithDepthMode depth Nothing
 
 -- -- | To test with DNE and depth tuning
 executeWithDNEDepth :: Int
-  -> QT.ProofSearchQuery
-  -> QT.ProofSearchResult
+  -> U.ProofSearchQuery
+  -> ProofSearchResult
 executeWithDNEDepth depth = executeWithDepthMode depth (Just QT.Classical)
 
 -- | To test time with depth tuning 
@@ -79,15 +82,15 @@ executeTimeWithDepth test = do
   putStrLn (show$TIME.diffUTCTime end start)
 
 -- -- | constant term, p
-p :: U.Preterm DTT
+p :: U.Preterm
 p = U.Con "p"
 
 -- | constant term, q
-q :: U.Preterm DTT
+q :: U.Preterm
 q = U.Con "q"
 
 -- | constant term, r
-r :: U.Preterm DTT
+r :: U.Preterm
 r = U.Con "r"
 
 -- | constant List
@@ -95,5 +98,9 @@ sigEs :: U.Signature
 sigEs = [("r",U.Type),("q",U.Type),("p",U.Type)]
 
 -- | Used to perform a batch of tests
-checkTests :: [TestType] -> Bool 
-checkTests ts = and $ map (\f -> let (predicted,result) = f in predicted == (not $ null $ result) ) ts
+checkTests :: [TestType] -> IO Bool 
+checkTests ts = do
+  results <- forM ts $ \(predicted,result) -> do
+    isNull <- ListT.null result
+    return $ predicted == not isNull
+  return $ and results

--- a/src/Problems/DifficultProblems.hs
+++ b/src/Problems/DifficultProblems.hs
@@ -4,10 +4,8 @@ module Problems.DifficultProblems(
   notYes
 )
  where
-import qualified DTS.UDTTdeBruijn as U
+import qualified DTS.DTTdeBruijn as U
 import ProblemBase as PB
-import qualified DTS.QueryTypes as QT (ProofSearchQuery(..))
-import DTS.Labels (DTT)
 
 yes :: [TestType]
 yes = [
@@ -42,7 +40,7 @@ choiceTest =
       U.Pi 
         (U.Pi (U.Con "A") (U.Sigma (U.App (U.Con "B") (U.Var 0)) (U.App (U.App (U.Con "C") (U.Var 1)) (U.Var 0)))) 
         (U.Sigma (U.Pi (U.Con "A") (U.App (U.Con "B") (U.Var 0))) (U.Pi (U.Con "A") (U.App (U.App (U.Con "C") (U.Var 0)) (U.App (U.Var 1) (U.Var 0)))))
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 dniTest:: TestType
 dniTest =
@@ -50,14 +48,14 @@ dniTest =
     sigEnv = [("a",U.Type)]
     varEnv = [U.Con "a"]
     pre_type = U.Not $U.Not (U.Con "a")
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 dniTest2 :: TestType
 dniTest2 =
   let sigEnv = []
       varEnv = [U.Type]
       pre_type =  U.Pi (U.Var 0) (U.Not (U.Not (U.Var 1)))
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 transitive :: TestType
 transitive =
@@ -65,7 +63,7 @@ transitive =
     sigEnv = sigEs
     varEnv = []
     pre_type = U.Pi (U.Pi p q) (U.Pi (U.Pi q r) (U.Pi p r))
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piElimTest6 :: TestType
 piElimTest6 =
@@ -73,14 +71,14 @@ piElimTest6 =
     sigEnv = sigEs
     varEnv = [U.Pi p q,U.Pi q r]
     pre_type =  U.Pi p r
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 efq :: TestType
 efq =
   let sigEnv = []
       varEnv = [U.Type, U.Bot]
       pre_type = U.Var 0
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 lem :: TestType
 lem =
@@ -88,7 +86,7 @@ lem =
     sigEnv = sigEs
     varEnv = [U.Type]
     pre_type = U.Not (U.Sigma (U.Not $ U.Var 0) (U.Not (U.Not (U.Var 1))))
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 tnd :: TestType
 tnd =
@@ -96,7 +94,7 @@ tnd =
     sigEnv = sigEs
     varEnv = []
     pre_type = U.Pi (U.Pi p q) (U.Pi (U.Pi (U.Not p) q) q)
-  in (True,executeWithDNEDepth 9 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 9 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 pars :: TestType -- depth 9以上
 pars =
@@ -104,7 +102,7 @@ pars =
     sigEnv = sigEs
     varEnv = []
     pre_type = U.Pi (U.Pi (U.Pi p q) p) p
-  in (True,executeWithDNEDepth 10 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 10 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 gem :: TestType
 gem =
@@ -112,7 +110,7 @@ gem =
     sigEnv = sigEs
     varEnv = [U.Type,U.Type]
     pre_type = U.Not (U.Sigma (U.Not (U.Pi p q)) (U.Not p))
-  in (True,executeWithDNEDepth 7 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 7 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 cm :: TestType
 cm =
@@ -120,7 +118,7 @@ cm =
     sigEnv = sigEs
     varEnv = []
     pre_type =  U.Pi (U.Pi p (U.Pi p U.Bot)) (U.Pi p U.Bot)
-  in  (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in  (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 
 con1 :: TestType
@@ -129,7 +127,7 @@ con1 =
     sigEnv = sigEs
     varEnv = []
     pre_type = U.Pi (U.Pi p q) (U.Pi (U.Not q) (U.Not p))
-  in    (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in    (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 con2 :: TestType
 con2 =
@@ -137,7 +135,7 @@ con2 =
     sigEnv = sigEs
     varEnv = []
     pre_type = U.Pi (U.Pi p (U.Not q)) (U.Pi q (U.Not p))
-  in    (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in    (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 con3 :: TestType
 con3 =
@@ -145,7 +143,7 @@ con3 =
     sigEnv = sigEs
     varEnv = []
     pre_type = U.Pi (U.Pi (U.Not q)  p) (U.Pi (U.Not p) q)
-  in    (True,executeWithDNEDepth 6 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in    (True,executeWithDNEDepth 6 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 con4 :: TestType
 con4 =
@@ -153,7 +151,7 @@ con4 =
     sigEnv = sigEs
     varEnv = []
     pre_type = U.Pi (U.Pi (U.Not p)  (U.Not q)) (U.Pi q p)
-  in   (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in   (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 mp :: TestType
 mp =
@@ -161,7 +159,7 @@ mp =
     sigEnv = sigEs
     varEnv = [U.Pi p q, p]
     pre_type = q
-  in    (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in    (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 s :: TestType
 s =
@@ -169,7 +167,7 @@ s =
     sigEnv = sigEs
     varEnv = []
     pre_type = U.Pi (U.Pi p (U.Pi q r)) (U.Pi (U.Pi p q) (U.Pi p r))
-  in    (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in    (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 k :: TestType
 k =
@@ -177,4 +175,4 @@ k =
     sigEnv = sigEs
     varEnv = []
     pre_type =U.Pi p (U.Pi q p)
-  in    (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in    (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))

--- a/src/Problems/NLPProblems.hs
+++ b/src/Problems/NLPProblems.hs
@@ -4,12 +4,10 @@ module Problems.NLPProblems (
   notYes
 )
  where
-import qualified DTS.UDTTdeBruijn as U
+import qualified DTS.DTTdeBruijn as U
 import qualified Data.Text.Lazy as T
 import qualified Data.Text.Lazy.IO as T
 import ProblemBase as PB
-import qualified DTS.QueryTypes as QT (ProofSearchQuery(..))
-import DTS.Labels (DTT)
 
 yes :: [PB.TestType]
 yes = [
@@ -21,13 +19,13 @@ yes = [
 notYes :: [PB.TestType]
 notYes = []
 
-thereIsA :: T.Text -> U.Preterm DTT
+thereIsA :: T.Text -> U.Preterm
 thereIsA txt = U.Sigma (U.Con "entity") (U.App (U.Con txt) (U.Var 0))
 
-thereIsAGirl :: U.Preterm DTT
+thereIsAGirl :: U.Preterm
 thereIsAGirl = thereIsA "girl"
 
-aGirlWritesAThesis :: U.Preterm DTT
+aGirlWritesAThesis :: U.Preterm
 aGirlWritesAThesis = 
     U.Sigma 
         (thereIsAGirl)
@@ -42,9 +40,9 @@ aGirlWritesAThesis_IsThereAGirl =
     sigEnv = [("write",U.Pi (U.Con "entity") (U.Pi (U.Con "entity") (U.Type))),("thesis",U.Pi (U.Con "entity") (U.Type)),("girl",U.Pi (U.Con "entity") (U.Type)),("entity",U.Type)]
     varEnv = [aGirlWritesAThesis]
     pre_type = thereIsAGirl
-  in (True,executeWithDNEDepth 3 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 3 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
-aGirlWritesAThesis' :: U.Preterm DTT
+aGirlWritesAThesis' :: U.Preterm
 aGirlWritesAThesis' = 
     U.Sigma 
         (U.Sigma 
@@ -59,9 +57,9 @@ aGirlWritesAThesis_IsThereAGirl'  =
     sigEnv = [("write",U.Pi (U.Con "entity") (U.Pi (U.Con "entity") (U.Type))),("thesis",U.Pi (U.Con "entity") (U.Type)),("girl",U.Pi (U.Con "entity") (U.Type)),("entity",U.Type)]
     varEnv = [aGirlWritesAThesis']
     pre_type = thereIsAGirl
-  in (True,executeWithDNEDepth 3 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 3 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
-aManEntersHeWhistle :: U.Preterm DTT
+aManEntersHeWhistle :: U.Preterm
 aManEntersHeWhistle = 
     U.Sigma 
         (U.Sigma (U.Con "entity") (U.App (U.Con "man") (U.Var 0)))
@@ -70,11 +68,11 @@ aManEntersHeWhistle =
             (U.App (U.Con "whistle") (U.Proj U.Fst $U.Var 1))
         )
 
-aManWhistle :: U.Preterm DTT
+aManWhistle :: U.Preterm
 aManWhistle = 
     U.Sigma (U.Con "entity") (U.App (U.Con "whistle") (U.Var 0))
 
-thereIsAMan :: U.Preterm DTT
+thereIsAMan :: U.Preterm
 thereIsAMan = thereIsA "man"
 
 aManEntersHeWhistle_IsThereWhistler :: PB.TestType
@@ -83,7 +81,7 @@ aManEntersHeWhistle_IsThereWhistler =
     sigEnv = [("whistle",U.Pi (U.Con "entity") (U.Type)),("enter",U.Pi (U.Con "entity") (U.Type)),("man",U.Pi (U.Con "entity") (U.Type)),("entity",U.Type)]
     varEnv = [aManEntersHeWhistle]
     pre_type = aManWhistle
-  in (True,executeWithDNEDepth 2 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 2 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 aManEntersHeWhistle_IsThereMan :: PB.TestType
 aManEntersHeWhistle_IsThereMan =
@@ -91,4 +89,4 @@ aManEntersHeWhistle_IsThereMan =
     sigEnv = [("whistle",U.Pi (U.Con "entity") (U.Type)),("enter",U.Pi (U.Con "entity") (U.Type)),("man",U.Pi (U.Con "entity") (U.Type)),("entity",U.Type)]
     varEnv = [aManEntersHeWhistle]
     pre_type = thereIsAMan
-  in (True,executeWithDNEDepth 3 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 3 (U.ProofSearchQuery sigEnv varEnv pre_type))

--- a/src/Problems/SimpleProblems.hs
+++ b/src/Problems/SimpleProblems.hs
@@ -4,10 +4,8 @@ module Problems.SimpleProblems(
   notYes
 )
 where
-import qualified DTS.UDTTdeBruijn as U
+import qualified DTS.DTTdeBruijn as U
 import ProblemBase as PB
-import qualified DTS.QueryTypes as QT (ProofSearchQuery(..))
-import DTS.Labels (DTT)
 
 yes :: [TestType]
 yes = [
@@ -73,7 +71,7 @@ membershipTest1 =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Con "entity"]
     pre_type = U.Con "entity"
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 membershipTest2 :: TestType
 membershipTest2 =
@@ -81,7 +79,7 @@ membershipTest2 =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Type,U.Con "entity"]
     pre_type = U.Con "entity"
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 membershipTestNotFound :: TestType
 membershipTestNotFound =
@@ -89,7 +87,7 @@ membershipTestNotFound =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Type,U.Type]
     pre_type = U.Con "entity"
-  in (False,executeWithDNEDepth 5 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (False,executeWithDNEDepth 5 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 membershipTestNotFound2 :: TestType
 membershipTestNotFound2 =
@@ -97,7 +95,7 @@ membershipTestNotFound2 =
     sigEnv = [("q",U.Type),("p",U.Type),("entity",U.Type)]
     varEnv = [U.Con "p"]
     pre_type = U.App (U.Con "q") (U.Con "p")
-  in (False,executeWithDNEDepth 5 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (False,executeWithDNEDepth 5 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 membershipTestNotFound3 :: TestType
 membershipTestNotFound3 =
@@ -105,7 +103,7 @@ membershipTestNotFound3 =
     sigEnv = [("q",U.Type),("p",U.Type),("entity",U.Type)]
     varEnv = [U.Var 0,U.Type,U.Type]
     pre_type = U.Var 2
-  in (False,executeWithDNEDepth 5 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (False,executeWithDNEDepth 5 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 membershipTestForward1 :: TestType
 membershipTestForward1 =
@@ -113,7 +111,7 @@ membershipTestForward1 =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Type,U.Sigma (U.Type) $U.Sigma U.Type (U.Con "entity")]
     pre_type = U.Con "entity"
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 membershipTestForward2 :: TestType
 membershipTestForward2 =
@@ -121,7 +119,7 @@ membershipTestForward2 =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Type,U.Pi (U.Con "entity") $U.Sigma (U.Con "entity") (U.Type)]
     pre_type = U.Pi (U.Con "entity") U.Type
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqIntroTest1 :: TestType
 eqIntroTest1 =
@@ -129,7 +127,7 @@ eqIntroTest1 =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Con "entity",U.Pi (U.Con "entity") $U.Sigma (U.Con "entity") (U.Con "entity")]
     pre_type = U.Eq (U.Con "entity") (U.Var 0) (U.Var 0)
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piIntroTest1 :: TestType
 piIntroTest1 =
@@ -137,7 +135,7 @@ piIntroTest1 =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Type,U.Con "entity"]
     pre_type = U.Pi (U.Var 0) (U.Var 1)
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piIntroTest2 :: TestType
 piIntroTest2 =
@@ -145,7 +143,7 @@ piIntroTest2 =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Con "entity",U.Type,U.Con "entity"]
     pre_type = U.Pi (U.Var 1) (U.Con "entity")
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piIntroTest3 :: TestType
 piIntroTest3 =
@@ -153,7 +151,7 @@ piIntroTest3 =
     sigEnv = [("event",U.Pi (U.Con "entity") U.Type),("entity",U.Type)]
     varEnv = [U.Con "entity",U.Type,U.Pi (U.Con "entity") U.Type]
     pre_type = U.Pi (U.Var 1) (U.Con "entity")
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piElimTest1 :: TestType
 piElimTest1 =
@@ -161,7 +159,7 @@ piElimTest1 =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Type,U.Pi (U.Var 2) (U.Var 1) ,U.Type,U.Var 0,U.Type]
     pre_type = U.Var 2
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piElimTest2 :: TestType
 piElimTest2 =
@@ -169,7 +167,7 @@ piElimTest2 =
     sigEnv = [("r",U.Type),("q",U.Type),("p",U.Type),("entity",U.Type)]
     varEnv = [U.Type,U.Pi (U.Con "p") (U.Pi (U.Con "q") (U.Con "r")),U.Con "q",U.Con "p"]
     pre_type = U.Con "r"
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piElimTest3 :: TestType
 piElimTest3 =
@@ -177,7 +175,7 @@ piElimTest3 =
     sigEnv = [("r",U.Type),("q",U.Type),("p",U.Type),("entity",U.Type)]
     varEnv = [U.Type,U.Pi (U.Con "p") (U.Pi (U.Con "p")(U.Pi (U.Con "q") (U.Con "r"))),U.Con "p"]
     pre_type = U.Pi (U.Con "q") (U.Con "r")
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piElimTest4 :: TestType
 piElimTest4 =
@@ -185,7 +183,7 @@ piElimTest4 =
     sigEnv = [("man",U.Pi (U.Con "entity") U.Type),("girl",U.Pi (U.Con "entity") U.Type),("x",U.Con "entity"),("event",U.Pi (U.Con "entity") U.Type),("entity",U.Type)]
     varEnv = [U.Pi (U.Con "entity") (U.Pi (U.App (U.Con "girl") (U.Var 0)) (U.App (U.Con "man") (U.Var 1))),U.App (U.Con "girl") (U.Con "x")]
     pre_type = U.App (U.Con "man") (U.Con "x")
-  in (True,executeWithDNEDepth 3 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 3 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piElimTestNotFound1 :: TestType
 piElimTestNotFound1 =
@@ -193,7 +191,7 @@ piElimTestNotFound1 =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Type,U.Pi (U.Var 2) (U.Var 1) ,U.Type,U.Var 0,U.Type]
     pre_type = U.Var 0
-  in (False,executeWithDNEDepth 5 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (False,executeWithDNEDepth 5 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piElimTestNotFound2 :: TestType
 piElimTestNotFound2 =
@@ -201,7 +199,7 @@ piElimTestNotFound2 =
     sigEnv = [("entity",U.Type)]
     varEnv = [U.Type,U.Pi (U.Var 0) (U.Var 1) ,U.Type,U.Var 0,U.Type]
     pre_type = U.Var 2
-  in (False,executeWithDNEDepth 5 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (False,executeWithDNEDepth 5 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqIntroTestNotFound :: TestType
 eqIntroTestNotFound =
@@ -209,7 +207,7 @@ eqIntroTestNotFound =
     sigEnv = [("love",U.Pi (U.Con "entity") (U.Pi (U.Con "entity") U.Type)),("man",U.Pi (U.Con "entity") U.Type),("girl",U.Pi (U.Con "entity") U.Type),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = []
     pre_type = U.Eq (U.Type) (U.App (U.App (U.Con "love") (U.Con "y")) (U.Con "x")) (U.App (U.App (U.Con "love") (U.Con "y")) (U.Con "x"))
-  in (False,executeWithDNEDepth 5 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (False,executeWithDNEDepth 5 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTest1 :: TestType
 eqElimTest1 =
@@ -217,7 +215,7 @@ eqElimTest1 =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Eq (U.Con "entity") (U.Con "x") (U.Con "y"),U.App (U.Con "f") (U.Con "x")]
     pre_type = U.App (U.Con "f") (U.Con "y")
-  in (True,executeWithDNEDepth 6 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 6 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTest2 :: TestType
 eqElimTest2 =
@@ -225,7 +223,7 @@ eqElimTest2 =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.App (U.Con "f") (U.Con "x"),U.Eq (U.Con "entity") (U.Con "x") (U.Var 0),U.Con "entity"]
     pre_type = U.App (U.Con "f") (U.Var 2)
-  in (True,executeWithDNEDepth 4 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 4 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTest3 :: TestType
 eqElimTest3 =
@@ -233,7 +231,7 @@ eqElimTest3 =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.App (U.Con "f") (U.Var 2),U.Eq (U.Con "entity") (U.Var 0) (U.Var 1),U.Con "entity",U.Con "entity"]
     pre_type = U.App (U.Con "f") (U.Var 2)
-  in (True,executeWithDNEDepth 4 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 4 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTest4 :: TestType
 eqElimTest4 =
@@ -241,7 +239,7 @@ eqElimTest4 =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Eq (U.Con "entity") (U.Con "x") (U.Var 0),U.Con "entity",U.App (U.Con "f") (U.Con "x")]
     pre_type = U.App (U.Con "f") (U.Var 1)
-  in (True,executeWithDNEDepth 4 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 4 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTest5 :: TestType
 eqElimTest5 =
@@ -249,7 +247,7 @@ eqElimTest5 =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Eq (U.Con "entity") (U.Var 0) (U.Con "x") ,U.Con "entity",U.App (U.Con "f") (U.Con "x")]
     pre_type = U.App (U.Con "f") (U.Var 1)
-  in (True,executeWithDNEDepth 4 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 4 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 xy = U.Eq (U.Con "entity") (U.Con"x") (U.Con "y")
 yx = U.Eq (U.Con "entity") (U.Con"y") (U.Con "x")
@@ -264,7 +262,7 @@ transTest1 =
     sigEnv = [("z",U.Con "entity"),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [xy,yz]
     pre_type = xz
-  in (True,executeWithDNEDepth 3 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 3 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 transTest2 :: TestType
 transTest2 =
@@ -272,7 +270,7 @@ transTest2 =
     sigEnv = [("z",U.Con "entity"),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [xy,yz]
     pre_type = zx
-  in (True,executeWithDNEDepth 4 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 4 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 transTest3 :: TestType
 transTest3 =
@@ -280,7 +278,7 @@ transTest3 =
     sigEnv = [("z",U.Con "entity"),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [xy,zy]
     pre_type = xz
-  in (True,executeWithDNEDepth 2 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 2 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 transTest4 :: TestType
 transTest4 =
@@ -288,7 +286,7 @@ transTest4 =
     sigEnv = [("z",U.Con "entity"),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [xy,zy]
     pre_type = zx
-  in (True,executeWithDNEDepth 2 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 2 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 transTest5 :: TestType
 transTest5 =
@@ -296,7 +294,7 @@ transTest5 =
     sigEnv = [("z",U.Con "entity"),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [yx,yz]
     pre_type = xz
-  in (True,executeWithDNEDepth 4 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 4 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 transTest6 :: TestType
 transTest6 =
@@ -304,7 +302,7 @@ transTest6 =
     sigEnv = [("z",U.Con "entity"),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [yx,yz]
     pre_type = zx
-  in (True,executeWithDNEDepth 4 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 4 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 transTest7 :: TestType
 transTest7 =
@@ -312,7 +310,7 @@ transTest7 =
     sigEnv = [("z",U.Con "entity"),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [yx,zy]
     pre_type = xz
-  in (True,executeWithDNEDepth 4 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 4 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 transTest8 :: TestType
 transTest8 =
@@ -320,7 +318,7 @@ transTest8 =
     sigEnv = [("z",U.Con "entity"),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [yx,zy]
     pre_type = zx
-  in (True,executeWithDNEDepth 3 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 3 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTestApp :: TestType
 eqElimTestApp =
@@ -328,7 +326,7 @@ eqElimTestApp =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.App (U.Con "f") (U.Con "y"),U.Eq (U.Con "entity") (U.Con "x") (U.Con "y")]
     pre_type = U.App (U.Con "f") (U.Con "x")
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTestApp2 :: TestType
 eqElimTestApp2 =
@@ -336,7 +334,7 @@ eqElimTestApp2 =
     sigEnv = [("sister",U.Pi (U.Con "entity") (U.Con "entity")),("family",U.Pi (U.Con "entity") (U.Con "entity")),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.App (U.Con "sister") (U.Con "x"),U.Eq (U.Pi (U.Con "entity") (U.Con "entity")) (U.Con "family") (U.Con "sister")]
     pre_type = U.App (U.Con "family") (U.Con "x")
-  in (True,executeWithDNEDepth 5 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 5 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTestSigma1 :: TestType
 eqElimTestSigma1 =
@@ -344,7 +342,7 @@ eqElimTestSigma1 =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Sigma (U.App (U.Con "f") (U.Con "x")) (U.App (U.Con "f") (U.Con "x")),U.Eq (U.Con "entity") (U.Con "x") (U.Con "y")]
     pre_type = U.Sigma (U.App (U.Con "f") (U.Con "x")) (U.App (U.Con "f") (U.Con "y"))
-  in (True,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTestPi1 :: TestType
 eqElimTestPi1 =
@@ -352,7 +350,7 @@ eqElimTestPi1 =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Pi (U.App (U.Con "f") (U.Con "x")) (U.App (U.Con "f") (U.Con "x")),U.Eq (U.Con "entity") (U.Con "x") (U.Con "y")]
     pre_type = U.Pi (U.App (U.Con "f") (U.Con "x")) (U.App (U.Con "f") (U.Con "y"))
-  in (True,executeWithDNEDepth 6 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 6 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTestPiNotFound :: TestType
 eqElimTestPiNotFound =
@@ -360,7 +358,7 @@ eqElimTestPiNotFound =
     sigEnv = [("z",U.Type),("y",U.Type),("x",U.Type),("entity",U.Type)]
     varEnv = [U.Pi (U.Con "z") (U.Con "x"),U.Eq (U.Type) (U.Con "x") (U.Con "y")]
     pre_type = U.Pi (U.Con "z") (U.Con "y")
-  in (False,executeWithDNEDepth 7 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (False,executeWithDNEDepth 7 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTestPi2 :: TestType
 eqElimTestPi2 =
@@ -368,7 +366,7 @@ eqElimTestPi2 =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("z",U.Con "entity"),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Pi (U.App (U.Con "f") (U.Con "z")) (U.App (U.Con "f") (U.Con "x")),U.Eq (U.Con "entity") (U.Con "x") (U.Con "y")]
     pre_type = U.Pi (U.App (U.Con "f") (U.Con "z")) (U.App (U.Con "f") (U.Con "y"))
-  in (True,executeWithDNEDepth 5 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 5 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTestPi3 :: TestType
 eqElimTestPi3 =
@@ -376,7 +374,7 @@ eqElimTestPi3 =
     sigEnv = [("x",U.Type),("entity",U.Type)]
     varEnv = []
     pre_type = U.Pi (U.Con "x") (U.Con "x")
-  in (True,executeWithDNEDepth 7 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 7 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTestSigmaNotFound :: TestType
 eqElimTestSigmaNotFound =
@@ -384,7 +382,7 @@ eqElimTestSigmaNotFound =
     sigEnv = [("z",U.Type),("y",U.Type),("x",U.Type),("entity",U.Type)]
     varEnv = [U.Sigma (U.Con "x") (U.Pi (U.Con "z") (U.Con "x")),U.Eq (U.Type) (U.Con "x") (U.Con "y")]
     pre_type = U.Sigma (U.Con "x") (U.Pi (U.Con "z") (U.Con "y"))
-  in (False,executeWithDNEDepth 7 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (False,executeWithDNEDepth 7 (U.ProofSearchQuery sigEnv varEnv pre_type))
  
 eqElimTestSigma2 :: TestType
 eqElimTestSigma2 =
@@ -392,7 +390,7 @@ eqElimTestSigma2 =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("z",U.Con "entity"),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Sigma (U.App (U.Con "f") (U.Con "x")) (U.Pi (U.App (U.Con "f") (U.Con "z")) (U.App (U.Con "f") (U.Con "x"))),U.Eq (U.Con "entity") (U.Con "x") (U.Con "y")]
     pre_type = U.Sigma (U.App (U.Con "f") (U.Con "x")) (U.Pi (U.App (U.Con "f") (U.Con "z")) (U.App (U.Con "f") (U.Con "y")))
-  in (True,executeWithDNEDepth 6 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 6 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 eqElimTestNotFound1 :: TestType
 eqElimTestNotFound1 =
@@ -400,7 +398,7 @@ eqElimTestNotFound1 =
     sigEnv = [("f",U.Pi (U.Con "entity") U.Type),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Eq (U.Con "entity") (U.Con "x") (U.Var 0),U.Con "entity", U.App (U.Con "f") (U.Con "x")]
     pre_type = U.App (U.Con "f") (U.Con "y")
-  in (False,executeWithDNEDepth 4 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (False,executeWithDNEDepth 4 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 dneTest1 :: TestType
 dneTest1 =
@@ -408,7 +406,7 @@ dneTest1 =
     sigEnv = []
     varEnv = [U.Not $ U.Not (U.Var 0),U.Type]
     pre_type = U.Var 1
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 dneTest2 :: TestType
 dneTest2 =
@@ -416,7 +414,7 @@ dneTest2 =
     sigEnv = [("man",U.Pi (U.Con "entity") (U.Type)),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Not $ U.Not (U.App (U.Con "man") (U.Con "y"))]
     pre_type = U.App (U.Con "man") (U.Con "y")
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 dneTest3 :: TestType
 dneTest3 =
@@ -424,7 +422,7 @@ dneTest3 =
     sigEnv = [("man",U.Pi (U.Con "entity") (U.Type)),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Not $ U.Not (U.App (U.Con "man") (U.Con "x")),U.Eq (U.Con "entity") (U.Con "x") (U.Con "y")]
     pre_type = U.App (U.Con "man") (U.Con "x")
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 dneTest4 :: TestType
 dneTest4 =
@@ -432,7 +430,7 @@ dneTest4 =
     sigEnv = [("man",U.Pi (U.Con "entity") (U.Type)),("y",U.Con "entity"),("x",U.Con "entity"),("entity",U.Type)]
     varEnv = [U.Not $ U.Not (U.App (U.Con "man") (U.Con "x")),U.Eq (U.Con "entity") (U.Con "x") (U.Con "y")]
     pre_type = U.App (U.Con "man") (U.Con "y")
-  in (True,executeWithDNEDepth 6 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 6 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 sigmaIntroTest1 :: TestType
 sigmaIntroTest1 =
@@ -440,7 +438,7 @@ sigmaIntroTest1 =
     sigEnv = [("man",U.Pi (U.Con "entity") (U.Type)),("entity",U.Type)]
     varEnv = [U.App (U.Con "man") (U.Var 0),U.Con "entity"]
     pre_type = U.Sigma (U.Con "entity") (U.Con "entity")
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 sigmaIntroTest2 :: TestType
 sigmaIntroTest2 =
@@ -448,7 +446,7 @@ sigmaIntroTest2 =
     sigEnv = [("dog",U.Pi (U.Con "entity") (U.Type)),("love",U.Pi (U.Con "entity") (U.Pi (U.Con "entity") U.Type)),("man",U.Pi (U.Con "entity") (U.Type)),("entity",U.Type)]
     varEnv = [U.App (U.App (U.Con "love") (U.Var 3)) (U.Var 1),U.App (U.Con "dog") (U.Var 0),U.Con "entity",U.App (U.Con "man") (U.Var 0),U.Con "entity"]
     pre_type = U.Sigma (U.Con "entity") (U.Sigma (U.Con "entity") (U.Sigma (U.App (U.Con "man") (U.Var 1)) (U.Sigma (U.App (U.App (U.Con "love") (U.Var 2)) (U.Var 1)) (U.App (U.Con "dog") (U.Var 6)))))
-  in (True,executeWithDNEDepth 3 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNEDepth 3 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 false :: TestType
 false =
@@ -456,7 +454,7 @@ false =
     sigEnv = []
     varEnv = [U.Type]
     pre_type =  U.Bot
-  in  (False,execute QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in  (False,execute (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piElimTest5 :: TestType
 piElimTest5 =
@@ -464,7 +462,7 @@ piElimTest5 =
     sigEnv = sigEs
     varEnv = [p,U.Pi p q,U.Pi q r]
     pre_type =  r
-  in(True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in(True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 piElimTest6 :: TestType
 piElimTest6 =
@@ -472,7 +470,7 @@ piElimTest6 =
     sigEnv = sigEs
     varEnv = [U.Pi (U.Var 2) (U.Var 2),U.Pi (U.Var 2) (U.Var 2),U.Type,U.Type,U.Type]
     pre_type =  U.Pi (U.Var 4) (U.Var 3)
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 dneTest5 :: TestType
 dneTest5 =
@@ -480,4 +478,4 @@ dneTest5 =
     sigEnv = sigEs
     varEnv = [p,U.Pi q r,U.Pi p (U.Pi (U.Pi q U.Bot) U.Bot)]
     pre_type = r
-  in (True,executeWithDNE QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,executeWithDNE (U.ProofSearchQuery sigEnv varEnv pre_type))

--- a/src/Problems/minimum.hs
+++ b/src/Problems/minimum.hs
@@ -4,10 +4,9 @@ module Problems.Minimum (
   notYes
 )
 where
-import qualified DTS.UDTTdeBruijn as U
+import qualified DTS.DTTdeBruijn as U
 import qualified ProblemBase as PB
 import qualified DTS.Prover.Wani.WaniBase as B
-import qualified DTS.QueryTypes as QT (ProofSearchQuery(..))
 
 yes :: [PB.TestType]
 yes = [testYes]
@@ -21,7 +20,7 @@ testYes =
     sigEnv = [("man",U.Pi (U.Con "entity") U.Type),("girl",U.Pi (U.Con "entity") U.Type),("x",U.Con "entity"),("event",U.Pi (U.Con "entity") U.Type),("entity",U.Type)]
     varEnv = [U.Pi (U.Con "entity") (U.Pi (U.App (U.Con "girl") (U.Var 0)) (U.App (U.Con "man") (U.Var 1))),U.App (U.Con "girl") (U.Con "x")]
     pre_type = U.App (U.Con "man") (U.Con "x")
-  in (True,PB.executeWithDepth 3 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (True,PB.executeWithDepth 3 (U.ProofSearchQuery sigEnv varEnv pre_type))
 
 testNo :: PB.TestType
 testNo = 
@@ -29,4 +28,4 @@ testNo =
     sigEnv = [("man",U.Pi (U.Con "entity") U.Type),("girl",U.Pi (U.Con "entity") U.Type),("x",U.Con "entity"),("event",U.Pi (U.Con "entity") U.Type),("entity",U.Type)]
     varEnv = [U.Pi (U.Con "entity") (U.Pi (U.App (U.Con "girl") (U.Var 0)) (U.App (U.Con "man") (U.Var 1))),U.App (U.Con "girl") (U.Con "x")]
     pre_type = U.Not $ U.App (U.Con "man") (U.Con "x")
-  in (False,PB.executeWithDepth 3 QT.ProofSearchQuery{QT.sig=sigEnv,QT.ctx=varEnv,QT.typ=pre_type})
+  in (False,PB.executeWithDepth 3 (U.ProofSearchQuery sigEnv varEnv pre_type))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,14 @@
-resolver: lts-15.1
+resolver: lts-18.28
 
 flags: {}
 
 extra-deps:
-  - git: git@github.com:DaisukeBekki/JSeM.git
-    commit: d5705b42006a08aa9dd8d2ea37d29fc7cf5559f6
+  - git: http://github.com/DaisukeBekki/JSeM.git
+    commit: b725e62dd66cbbb4fe891ee84108d7a398f5dd71
   - git: git@github.com:DaisukeBekki/hasktorch-tools.git
     commit: 936928cdee27e179a5e3775d146046b107b0eba1
   - git: https://github.com/DaisukeBekki/lightblue.git
-    commit: a230595f5e674d0457051322801ba22e94033ec3
+    commit: b92288d6b19ec1311e17b206e991d78a0ddb0341
   # - /Users/daidohinari/blab/mycode/lightblue
 
 build:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,30 +5,30 @@
 
 packages:
 - completed:
+    commit: b725e62dd66cbbb4fe891ee84108d7a398f5dd71
+    git: http://github.com/DaisukeBekki/JSeM.git
     name: jsem
-    version: 0.1.4
-    git: git@github.com:DaisukeBekki/JSeM.git
     pantry-tree:
-      size: 5360
-      sha256: e6ae8d999fd1f0d0e715e779f9cb660bb5d11b5a554d7e9e940f6dee7efa699d
-    commit: d5705b42006a08aa9dd8d2ea37d29fc7cf5559f6
+      sha256: 850e765ff576f8ecb4026513ca1f8ea79e88772351b1f56f9ba2545aeb18ac2d
+      size: 5986
+    version: 0.1.5
   original:
-    git: git@github.com:DaisukeBekki/JSeM.git
-    commit: d5705b42006a08aa9dd8d2ea37d29fc7cf5559f6
+    commit: b725e62dd66cbbb4fe891ee84108d7a398f5dd71
+    git: http://github.com/DaisukeBekki/JSeM.git
 - completed:
+    commit: 936928cdee27e179a5e3775d146046b107b0eba1
+    git: git@github.com:DaisukeBekki/hasktorch-tools.git
     name: hasktorch-tools
-    version: 0.2.0.0
-    git: git@github.com:DaisukeBekki/hasktorch-tools.git
     pantry-tree:
-      size: 1879
       sha256: 1fd35d65a133b370b8f9c59e76c662bc2be7948e9cf9be78bf90a726a43fbe34
-    commit: 936928cdee27e179a5e3775d146046b107b0eba1
+      size: 1879
+    version: 0.2.0.0
   original:
-    git: git@github.com:DaisukeBekki/hasktorch-tools.git
     commit: 936928cdee27e179a5e3775d146046b107b0eba1
+    git: git@github.com:DaisukeBekki/hasktorch-tools.git
 snapshots:
 - completed:
-    size: 489011
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/1.yaml
-    sha256: d4ecc42b7125d68e4c3c036a08046ad0cd02ae0d9efbe3af2223a00ff8cc16f3
-  original: lts-15.1
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
+    size: 590100
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
+  original: lts-18.28

--- a/waniTEST.cabal
+++ b/waniTEST.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -39,7 +39,8 @@ library
     , containers >=0.4
     , data-default
     , directory >=1.3.3.0
-    , lightblue
+    , lightblue >=0.3
+    , list-t >=1.0.0.0
     , mtl >=2.2.2
     , split
     , text >=1.2
@@ -60,7 +61,8 @@ executable waniTEST
     , containers >=0.4
     , data-default
     , directory >=1.3.3.0
-    , lightblue
+    , lightblue >=0.3
+    , list-t >=1.0.0.0
     , mtl >=2.2.2
     , split
     , text >=1.2


### PR DESCRIPTION
importしているlightblueのバージョンを0.3.3に上げました。主な変更点は以下の通りです。

- Preterm型の変更（DTS.DTTdeBruijnモジュールのPreterm型に統一）
- ProofSearchQuery型をQueryTypesモジュールからDTS.DTTdeBruijnモジュールに移動
- proverの返値を[Tree ...]からListT IO (Tree ...)型に変更。それに伴ってProblems.ProblemBaseモジュール内のcheckTestsコードを微修正